### PR TITLE
Downcase authentication_keys i18n param

### DIFF
--- a/lib/devise/failure_app.rb
+++ b/lib/devise/failure_app.rb
@@ -104,7 +104,7 @@ module Devise
         options[:default] = [message]
         auth_keys = scope_class.authentication_keys
         keys = (auth_keys.respond_to?(:keys) ? auth_keys.keys : auth_keys).map { |key| scope_class.human_attribute_name(key) }
-        options[:authentication_keys] = keys.join(I18n.translate(:"support.array.words_connector"))
+        options[:authentication_keys] = keys.join(I18n.translate(:"support.array.words_connector")).downcase
         options = i18n_options(options)
 
         I18n.t(:"#{scope}.#{message}", options)

--- a/test/failure_app_test.rb
+++ b/test/failure_app_test.rb
@@ -157,14 +157,14 @@ class FailureTest < ActiveSupport::TestCase
 
     test 'uses the proxy failure message as symbol' do
       call_failure('warden' => OpenStruct.new(message: :invalid))
-      assert_equal 'Invalid Email or password.', @request.flash[:alert]
+      assert_equal 'Invalid email or password.', @request.flash[:alert]
       assert_equal 'http://test.host/users/sign_in', @response.second["Location"]
     end
 
     test 'supports authentication_keys as a Hash for the flash message' do
       swap Devise, authentication_keys: { email: true, login: true } do
         call_failure('warden' => OpenStruct.new(message: :invalid))
-        assert_equal 'Invalid Email, Login or password.', @request.flash[:alert]
+        assert_equal 'Invalid email, login or password.', @request.flash[:alert]
       end
     end
 
@@ -250,7 +250,7 @@ class FailureTest < ActiveSupport::TestCase
 
     test 'uses the failure message as response body' do
       call_failure('formats' => Mime[:xml], 'warden' => OpenStruct.new(message: :invalid))
-      assert_match '<error>Invalid Email or password.</error>', @response.third.body
+      assert_match '<error>Invalid email or password.</error>', @response.third.body
     end
 
     context 'on ajax call' do
@@ -299,7 +299,7 @@ class FailureTest < ActiveSupport::TestCase
       }
       call_failure(env)
       assert @response.third.body.include?('<h2>Log in</h2>')
-      assert @response.third.body.include?('Invalid Email or password.')
+      assert @response.third.body.include?('Invalid email or password.')
     end
 
     test 'calls the original controller if not confirmed email' do
@@ -334,7 +334,7 @@ class FailureTest < ActiveSupport::TestCase
           }
           call_failure(env)
           assert @response.third.body.include?('<h2>Log in</h2>')
-          assert @response.third.body.include?('Invalid Email or password.')
+          assert @response.third.body.include?('Invalid email or password.')
           assert_equal @request.env["SCRIPT_NAME"], '/sample'
           assert_equal @request.env["PATH_INFO"], '/users/sign_in'
         end

--- a/test/integration/authenticatable_test.rb
+++ b/test/integration/authenticatable_test.rb
@@ -557,7 +557,7 @@ class AuthenticationKeysTest < Devise::IntegrationTest
   test 'missing authentication keys cause authentication to abort' do
     swap Devise, authentication_keys: [:subdomain] do
       sign_in_as_user
-      assert_contain "Invalid Subdomain or password."
+      assert_contain "Invalid subdomain or password."
       refute warden.authenticated?(:user)
     end
   end
@@ -596,7 +596,7 @@ class AuthenticationRequestKeysTest < Devise::IntegrationTest
 
     swap Devise, request_keys: [:subdomain] do
       sign_in_as_user
-      assert_contain "Invalid Email or password."
+      assert_contain "Invalid email or password."
       refute warden.authenticated?(:user)
     end
   end

--- a/test/integration/confirmable_test.rb
+++ b/test/integration/confirmable_test.rb
@@ -142,7 +142,7 @@ class ConfirmationTest < Devise::IntegrationTest
         fill_in 'password', with: 'invalid'
       end
 
-      assert_contain 'Invalid Email or password'
+      assert_contain 'Invalid email or password'
       refute warden.authenticated?(:user)
     end
   end

--- a/test/integration/database_authenticatable_test.rb
+++ b/test/integration/database_authenticatable_test.rb
@@ -70,7 +70,7 @@ class DatabaseAuthenticationTest < Devise::IntegrationTest
       fill_in 'password', with: 'abcdef'
     end
 
-    assert_contain 'Invalid Email or password'
+    assert_contain 'Invalid email or password'
     refute warden.authenticated?(:admin)
   end
 
@@ -82,7 +82,7 @@ class DatabaseAuthenticationTest < Devise::IntegrationTest
         end
         
         assert_not_contain 'Not found in database'
-        assert_contain 'Invalid Email or password.'
+        assert_contain 'Invalid email or password.'
       end
     end
   end

--- a/test/integration/http_authenticatable_test.rb
+++ b/test/integration/http_authenticatable_test.rb
@@ -52,7 +52,7 @@ class HttpAuthenticationTest < Devise::IntegrationTest
     sign_in_as_new_user_with_http("unknown")
     assert_equal 401, status
     assert_equal "application/xml; charset=utf-8", headers["Content-Type"]
-    assert_match "<error>Invalid Email or password.</error>", response.body
+    assert_match "<error>Invalid email or password.</error>", response.body
   end
 
   test 'returns a custom response with www-authenticate and chosen realm' do


### PR DESCRIPTION
To match case of error messages in which they are included.

Currently the messages look like:

`Invalid Email Address or password.`

and there is no way to fix it without changing the key under e.g. `activerecord.models.user.email`, which I obviously don't want to do.

Thanks for a great gem!